### PR TITLE
Support common tags for all resources

### DIFF
--- a/platform/ecrs/main.tf
+++ b/platform/ecrs/main.tf
@@ -7,9 +7,13 @@ resource "aws_ecr_repository" "ecr_image" {
   image_scanning_configuration {
     scan_on_push = false
   }
-  tags = {
-    "name" = "${var.prefix}: ${var.ecr_repo_name}"
-  }
+
+  tags = merge(
+    var.tags,
+    {
+      Notes = "${var.prefix}: ${var.ecr_repo_name}"
+    }
+  )
 }
 
 resource "aws_ecr_lifecycle_policy" "ecr_policy" {

--- a/platform/ecrs/main.tf
+++ b/platform/ecrs/main.tf
@@ -11,7 +11,7 @@ resource "aws_ecr_repository" "ecr_image" {
   tags = merge(
     var.tags,
     {
-      Notes = "${var.prefix}: ${var.ecr_repo_name}"
+      Name = "${var.prefix}: ${var.ecr_repo_name}"
     }
   )
 }

--- a/platform/ecrs/variables.tf
+++ b/platform/ecrs/variables.tf
@@ -12,3 +12,9 @@ variable "account_id" {}
 
 variable "aws_region" {}
 
+variable "tags" {
+  description = "(Optional) A mapping of tags to assign to the resources."
+  type        = map(string)
+  default     = {}
+}
+

--- a/platform/ecrs/variables.tf
+++ b/platform/ecrs/variables.tf
@@ -13,8 +13,7 @@ variable "account_id" {}
 variable "aws_region" {}
 
 variable "tags" {
-  description = "(Optional) A mapping of tags to assign to the resources."
+  description = "A mapping of tags to assign to the resources."
   type        = map(string)
-  default     = {}
 }
 

--- a/platform/iam_roles/main.tf
+++ b/platform/iam_roles/main.tf
@@ -9,9 +9,12 @@ resource "aws_iam_role" "mwaa-executor" {
   path                  = var.iam_role_path
   permissions_boundary  = var.iam_role_permissions_boundary
 
-  tags = {
-    Name = "IAM role for MWAA"
-  }
+  tags = merge(
+    var.tags,
+    {
+      Notes = "IAM role for MWAA"
+    }
+  )
 }
 
 resource "aws_iam_role_policy" "mwaa" {
@@ -34,4 +37,5 @@ resource "aws_iam_policy" "lambda_s3_event" {
   path        = "/"
   description = "Update MWAA when requirements updated"
   policy      = data.aws_iam_policy_document.lambda_s3_event_policy.json
+  tags = var.tags
 }

--- a/platform/iam_roles/main.tf
+++ b/platform/iam_roles/main.tf
@@ -12,7 +12,7 @@ resource "aws_iam_role" "mwaa-executor" {
   tags = merge(
     var.tags,
     {
-      Notes = "IAM role for MWAA"
+      Name = "IAM role for MWAA"
     }
   )
 }

--- a/platform/iam_roles/variables.tf
+++ b/platform/iam_roles/variables.tf
@@ -20,7 +20,6 @@ variable "iam_role_additional_arn_policies" {
 }
 
 variable "tags" {
-  description = "(Optional) A mapping of tags to assign to the resources."
+  description = "A mapping of tags to assign to the resources."
   type        = map(string)
-  default     = {}
 }

--- a/platform/iam_roles/variables.tf
+++ b/platform/iam_roles/variables.tf
@@ -18,3 +18,9 @@ variable "iam_role_additional_arn_policies" {
   description = "Additional policies to be added to the IAM role"
   type        = map(string)
 }
+
+variable "tags" {
+  description = "(Optional) A mapping of tags to assign to the resources."
+  type        = map(string)
+  default     = {}
+}

--- a/platform/mwaa/main.tf
+++ b/platform/mwaa/main.tf
@@ -20,6 +20,7 @@ module "s3_bucket" {
   lambda_s3_bucket_notification_arn = var.lambda_s3_bucket_notification_arn
   local_requirement_file_path       = var.local_requirement_file_path
   local_dag_folder                  = var.local_dag_folder
+  tags = var.tags
 }
 
 
@@ -30,6 +31,7 @@ module "iam_role" {
   mwaa_env_name                    = "${var.prefix}-mwaa"
   iam_role_additional_arn_policies = var.iam_role_additional_arn_policies
   iam_role_permissions_boundary    = var.iam_role_permissions_boundary
+  tags = var.tags
 }
 
 
@@ -38,6 +40,7 @@ module "security_groups" {
   source = "../security_groups"
   prefix = var.prefix
   vpc_id = var.vpc_id
+  tags = var.tags
 }
 
 
@@ -62,9 +65,7 @@ resource "aws_mwaa_environment" "mwaa" {
   webserver_access_mode           = var.webserver_access_mode
   weekly_maintenance_window_start = var.weekly_maintenance_window_start
 
-  tags = {
-    Name = "MWAA Impact Data pipeline"
-  }
+  tags = var.tags
 
   network_configuration {
     security_group_ids = module.security_groups.security_groups_ids

--- a/platform/mwaa/variables.tf
+++ b/platform/mwaa/variables.tf
@@ -76,3 +76,9 @@ variable "iam_role_permissions_boundary" {}
 variable "local_requirement_file_path" {}
 
 variable "local_dag_folder" {}
+
+variable "tags" {
+  description = "(Optional) A mapping of tags to assign to the resources."
+  type        = map(string)
+  default     = {}
+}

--- a/platform/mwaa/variables.tf
+++ b/platform/mwaa/variables.tf
@@ -78,7 +78,6 @@ variable "local_requirement_file_path" {}
 variable "local_dag_folder" {}
 
 variable "tags" {
-  description = "(Optional) A mapping of tags to assign to the resources."
+  description = "A mapping of tags to assign to the resources."
   type        = map(string)
-  default     = {}
 }

--- a/platform/s3_bucket/main.tf
+++ b/platform/s3_bucket/main.tf
@@ -4,9 +4,10 @@ locals {
 
 resource "aws_s3_bucket" "this" {
   bucket = var.bucket_name
-  tags = {
-    Name = "Bucket used for WMAA"
-  }
+
+  tags = merge(var.tags, {
+    "Notes" = "Bucket used for WMAA"
+  })
   lifecycle {
     prevent_destroy = true
   }

--- a/platform/s3_bucket/main.tf
+++ b/platform/s3_bucket/main.tf
@@ -6,7 +6,7 @@ resource "aws_s3_bucket" "this" {
   bucket = var.bucket_name
 
   tags = merge(var.tags, {
-    "Notes" = "Bucket used for WMAA"
+    "Name" = "Bucket used for WMAA"
   })
   lifecycle {
     prevent_destroy = true

--- a/platform/s3_bucket/variables.tf
+++ b/platform/s3_bucket/variables.tf
@@ -24,3 +24,9 @@ variable "local_requirement_file_path" {}
 
 
 variable "local_dag_folder" {}
+
+variable "tags" {
+  description = "(Optional) A mapping of tags to assign to the resources."
+  type        = map(string)
+  default     = {}
+}

--- a/platform/s3_bucket/variables.tf
+++ b/platform/s3_bucket/variables.tf
@@ -26,7 +26,6 @@ variable "local_requirement_file_path" {}
 variable "local_dag_folder" {}
 
 variable "tags" {
-  description = "(Optional) A mapping of tags to assign to the resources."
+  description = "A mapping of tags to assign to the resources."
   type        = map(string)
-  default     = {}
 }

--- a/platform/security_groups/main.tf
+++ b/platform/security_groups/main.tf
@@ -16,7 +16,7 @@ resource "aws_security_group" "mwaa" {
   tags = merge(
     var.tags,
     {
-      Notes = "${var.prefix}-mwaa-sg"
+      Name = "${var.prefix}-mwaa-sg"
     }
   )
 }

--- a/platform/security_groups/main.tf
+++ b/platform/security_groups/main.tf
@@ -13,9 +13,12 @@ resource "aws_security_group" "mwaa" {
     create_before_destroy = true
   }
 
-  tags = {
-    Name = "${var.prefix}-mwaa-sg"
-  }
+  tags = merge(
+    var.tags,
+    {
+      Notes = "${var.prefix}-mwaa-sg"
+    }
+  )
 }
 
 resource "aws_security_group_rule" "mwaa_sg_inbound" {

--- a/platform/security_groups/variables.tf
+++ b/platform/security_groups/variables.tf
@@ -4,3 +4,9 @@ variable "vpc_id" {}
 variable "source_cidr" {
   default = ["0.0.0.0/0"]
 }
+
+variable "tags" {
+  description = "(Optional) A mapping of tags to assign to the resources."
+  type        = map(string)
+  default     = {}
+}

--- a/platform/security_groups/variables.tf
+++ b/platform/security_groups/variables.tf
@@ -6,7 +6,6 @@ variable "source_cidr" {
 }
 
 variable "tags" {
-  description = "(Optional) A mapping of tags to assign to the resources."
+  description = "A mapping of tags to assign to the resources."
   type        = map(string)
-  default     = {}
 }

--- a/set_mwaa_variables.py
+++ b/set_mwaa_variables.py
@@ -13,7 +13,7 @@ def get_headers(mwaa_client, mwaa_env_name):
     }
     return {"headers": headers, "url": url}
 
-def get_va_without_double_quoites(val):
+def get_va_without_double_quotes(val):
     if '{' in val:
         return val
     elif isinstance(val, str):
@@ -29,7 +29,7 @@ def set_mwaa_env_var(mwaa_env_name,mwaa_vars_file_path, aws_region):
     headers_url = get_headers(mwaa_client=mwaa_client, mwaa_env_name=mwaa_env_name)
     for key in json_dictionary:
         print(key, " ", json_dictionary[key])
-        val = f"{key} '{get_va_without_double_quoites(json.dumps(json_dictionary[key]))}'"
+        val = f"{key} '{get_va_without_double_quotes(json.dumps(json_dictionary[key]))}'"
         raw_data = f"variables set {val}"
         mwaa_response = requests.post(
             headers_url['url'],

--- a/variables.tf
+++ b/variables.tf
@@ -3,7 +3,6 @@ variable "prefix" {
 }
 
 
-
 variable "create_security_group" {
   default = false
 }
@@ -87,11 +86,14 @@ variable "mwaa_variables_json_file_id_path" {
 
 
 variable "stage" {
-
   description = "Stage maturity (dev, sit, uat, prod...)"
 }
 
-
+variable "tags" {
+  description = "Tags to be added to resources"
+  type        = map(string)
+  default     = {}
+}
 
 variable "ecs_containers" {
   type = list(object({


### PR DESCRIPTION
This PR adds an optional "tags" variable. Passing a mapping of strings to this variable will apply that mapping as tags to all applicable AWS resources managed by this module. This can allow resources to be associated with certain projects, releases, and deployments.

By default, the `tags` variable is an empty mapping, and no tags are added (apart from those already included in the module).