### PR TITLE
Support specifying a startup script in the MWAA environment

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -78,7 +78,8 @@ module "mwaa" {
   dag_s3_path                       = var.dag_s3_path
   iam_role_permissions_boundary     = var.permissions_boundary_arn
   local_dag_folder                  = var.local_dag_folder == null ? "${path.module}/application/dags/" : var.local_dag_folder
-  local_requirement_file_path = var.local_requirement_file_path == null ? "${path.module}/application/requirements/requirements.txt" : var.local_requirement_file_path
+  local_requirement_file_path       = var.local_requirement_file_path == null ? "${path.module}/application/requirements/requirements.txt" : var.local_requirement_file_path
+  startup_script_file_path          = var.local_startup_script_file_path == null ? "${path.module}/application/requirements/startup.sh" : var.local_startup_script_file_path
   tags = local.common_tags
 }
 

--- a/main.tf
+++ b/main.tf
@@ -79,7 +79,7 @@ module "mwaa" {
   iam_role_permissions_boundary     = var.permissions_boundary_arn
   local_dag_folder                  = var.local_dag_folder == null ? "${path.module}/application/dags/" : var.local_dag_folder
   local_requirement_file_path       = var.local_requirement_file_path == null ? "${path.module}/application/requirements/requirements.txt" : var.local_requirement_file_path
-  startup_script_file_path          = var.local_startup_script_file_path == null ? "${path.module}/application/requirements/startup.sh" : var.local_startup_script_file_path
+  startup_script_file_path          = var.local_startup_script_file_path == var.local_startup_script_file_path
   tags = local.common_tags
 }
 

--- a/platform/mwaa/main.tf
+++ b/platform/mwaa/main.tf
@@ -19,6 +19,7 @@ module "s3_bucket" {
   dag_s3_path                       = var.dag_s3_path
   lambda_s3_bucket_notification_arn = var.lambda_s3_bucket_notification_arn
   local_requirement_file_path       = var.local_requirement_file_path
+  local_startup_script_file_path    = var.local_startup_script_file_path
   local_dag_folder                  = var.local_dag_folder
   tags = var.tags
 }
@@ -57,6 +58,7 @@ resource "aws_mwaa_environment" "mwaa" {
   plugins_s3_object_version     = var.plugins_s3_object_version
   plugins_s3_path               = module.s3_bucket.plugins_s3_path
   requirements_s3_path          = module.s3_bucket.requirements_s3_path
+  startup_script_s3_path        = module.s3_bucket.startup_script_s3_path
   schedulers                    = var.schedulers
   execution_role_arn            = module.iam_role.execution_role_arn
   airflow_configuration_options = local.airflow_configuration_options

--- a/platform/mwaa/variables.tf
+++ b/platform/mwaa/variables.tf
@@ -75,6 +75,8 @@ variable "iam_role_permissions_boundary" {}
 
 variable "local_requirement_file_path" {}
 
+variable "local_startup_script_file_path" {}
+
 variable "local_dag_folder" {}
 
 variable "tags" {

--- a/platform/mwaa/variables.tf
+++ b/platform/mwaa/variables.tf
@@ -75,7 +75,10 @@ variable "iam_role_permissions_boundary" {}
 
 variable "local_requirement_file_path" {}
 
-variable "local_startup_script_file_path" {}
+variable "local_startup_script_file_path" {
+  type       = string
+  default    = null
+}
 
 variable "local_dag_folder" {}
 

--- a/platform/s3_bucket/main.tf
+++ b/platform/s3_bucket/main.tf
@@ -62,7 +62,7 @@ resource "null_resource" "upload_dag_folder" {
     src_hash = data.archive_file.monitor_change_in_dag_folder.output_sha
   }
   provisioner "local-exec" {
-    command = "aws s3 sync --exclude 'requirements.txt' --exclude '*' --include '*.py' --include '*.txt' --size-only ${var.local_dag_folder} s3://${aws_s3_bucket.this.id}/${var.dag_s3_path}"
+    command = "aws s3 sync --exclude 'requirements.txt' --exclude 'startup.sh' --exclude '*' --include '*.py' --include '*.txt' --size-only ${var.local_dag_folder} s3://${aws_s3_bucket.this.id}/${var.dag_s3_path}"
   }
 }
 
@@ -82,6 +82,13 @@ resource "aws_s3_object" "reqs" {
   key    = "requirements/${var.requirements_filename}"
   source = var.local_requirement_file_path
   etag   = filemd5(var.local_requirement_file_path)
+}
+
+resource "aws_s3_object" "startup_script" {
+  bucket = aws_s3_bucket.this.id
+  key    = "requirements/${var.startup_script_filename}"
+  source = var.local_startup_script_file_path
+  etag   = filemd5(var.local_startup_script_file_path)
 }
 
 resource "aws_lambda_permission" "allow_bucket" {

--- a/platform/s3_bucket/main.tf
+++ b/platform/s3_bucket/main.tf
@@ -85,6 +85,7 @@ resource "aws_s3_object" "reqs" {
 }
 
 resource "aws_s3_object" "startup_script" {
+  count =  var.local_startup_script_file_path == null ? 0: 1
   bucket = aws_s3_bucket.this.id
   key    = "requirements/${var.startup_script_filename}"
   source = var.local_startup_script_file_path

--- a/platform/s3_bucket/outputs.tf
+++ b/platform/s3_bucket/outputs.tf
@@ -19,5 +19,5 @@ output "requirements_s3_path" {
 }
 
 output "startup_script_s3_path" {
-  value = aws_s3_object.startup_script.key
+  value = one(aws_s3_object.startup_script[*].key)
 }

--- a/platform/s3_bucket/outputs.tf
+++ b/platform/s3_bucket/outputs.tf
@@ -17,3 +17,7 @@ output "plugins_s3_path" {
 output "requirements_s3_path" {
   value = aws_s3_object.reqs.key
 }
+
+output "startup_script_s3_path" {
+  value = aws_s3_object.startup_script.key
+}

--- a/platform/s3_bucket/variables.tf
+++ b/platform/s3_bucket/variables.tf
@@ -26,7 +26,10 @@ variable "startup_script_filename" {
 variable "lambda_s3_bucket_notification_arn" {}
 # Upload requirements
 variable "local_requirement_file_path" {}
-variable "local_startup_script_file_path" {}
+variable "local_startup_script_file_path" {
+  type    = string
+  default = null
+}
 
 
 variable "local_dag_folder" {}

--- a/platform/s3_bucket/variables.tf
+++ b/platform/s3_bucket/variables.tf
@@ -14,13 +14,19 @@ variable "requirements_s3_path" {
   type        = string
   default     = "requirements"
 }
+
 variable "requirements_filename" {
   default = "requirements.txt"
+}
+
+variable "startup_script_filename" {
+  default = null
 }
 
 variable "lambda_s3_bucket_notification_arn" {}
 # Upload requirements
 variable "local_requirement_file_path" {}
+variable "local_startup_script_file_path" {}
 
 
 variable "local_dag_folder" {}

--- a/variables.tf
+++ b/variables.tf
@@ -69,6 +69,12 @@ variable "local_requirement_file_path" {
   default     = null
 }
 
+variable "local_startup_script_file_path" {
+  description = "Path for script that will run at startup of each worker"
+  type        = string
+  default     = null
+}
+
 variable "local_dag_folder" {
   description = "Path to dag folder"
   type        = string


### PR DESCRIPTION
This allows installing system-level dependencies, such as GDAL, on the workers.