### PR TITLE
Startup script bugfixes

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     aws = {
-      version = "~> 4.0"
+      version = "~> 4.67.0"
     }
   }
 }

--- a/platform/s3_bucket/variables.tf
+++ b/platform/s3_bucket/variables.tf
@@ -20,7 +20,7 @@ variable "requirements_filename" {
 }
 
 variable "startup_script_filename" {
-  default = null
+  default = "startup.sh"
 }
 
 variable "lambda_s3_bucket_notification_arn" {}


### PR DESCRIPTION
We need to spec a version of the AWS provider that definitely includes the ability to specify a startup_script_s3_path in aws_mwaa_environment.

Also missed specifying a default script name.