### PR TITLE
Avoid token expiry when setting multiple MWAA env vars

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     aws = {
-      version = "~> 4.0"
+      version = "~> 4.67.0"
     }
   }
 }

--- a/platform/s3_bucket/variables.tf
+++ b/platform/s3_bucket/variables.tf
@@ -20,7 +20,7 @@ variable "requirements_filename" {
 }
 
 variable "startup_script_filename" {
-  default = null
+  default = "startup.sh"
 }
 
 variable "lambda_s3_bucket_notification_arn" {}

--- a/set_mwaa_variables.py
+++ b/set_mwaa_variables.py
@@ -36,8 +36,19 @@ def set_mwaa_env_var(mwaa_env_name,mwaa_vars_file_path, aws_region):
             headers=headers_url['headers'],
             data=raw_data
         )
-        mwaa_std_err_message = base64.b64decode(mwaa_response.json()['stderr']).decode('utf8')
-        mwaa_std_out_message = base64.b64decode(mwaa_response.json()['stdout']).decode('utf8')
+        try:
+            mwaa_std_err_message = base64.b64decode(mwaa_response.json()['stderr']).decode('utf8')
+        except requests.JSONDecodeError as err:
+            print(err)
+            print(mwaa_response.text)
+            mwaa_std_err_message = mwaa_response.text
+        
+        try:
+            mwaa_std_out_message = base64.b64decode(mwaa_response.json()['stdout']).decode('utf8')
+        except requests.JSONDecodeError as err:
+            print(err)
+            print(mwaa_response.text)
+            mwaa_std_out_message = mwaa_response.text
         print(mwaa_response.status_code)
         print(mwaa_std_err_message)
         print(mwaa_std_out_message)

--- a/set_mwaa_variables.py
+++ b/set_mwaa_variables.py
@@ -2,6 +2,7 @@ import boto3
 import json
 import base64
 import requests
+import time
 from argparse import ArgumentParser
 
 def get_headers(mwaa_client, mwaa_env_name):
@@ -52,6 +53,7 @@ def set_mwaa_env_var(mwaa_env_name,mwaa_vars_file_path, aws_region):
         print(mwaa_response.status_code)
         print(mwaa_std_err_message)
         print(mwaa_std_out_message)
+        time.sleep(0.2)
 
 if __name__ == "__main__":
     parser = ArgumentParser(


### PR DESCRIPTION
When setting a large number of MWAA env vars, we ran into an issue where the auth token for the MWAA API had expired before we reached the end of the list. This PR checks for 403 errors and refreshes the token before retrying the failed request.

Note there are a few commits here which come from PR #10. Happy to split those out, if need be, though I would recommend also merging that PR.