### PR TITLE
fix: pass airflow_configuration_options to platform mwaa module

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -55,7 +55,7 @@ resource "aws_ecs_cluster" "mwaa_cluster" {
     name  = "containerInsights"
     value = "enabled"
   }
-  
+
   tags = local.common_tags
 }
 # ECS task section (Cluster + LOGS)  end
@@ -63,6 +63,7 @@ resource "aws_ecs_cluster" "mwaa_cluster" {
 module "mwaa" {
   source                            = "./platform/mwaa"
   airflow_version                   = var.airflow_version
+  airflow_configuration_options     = var.airflow_configuration_options
   environment_class                 = var.environment_class
   max_workers                       = var.max_workers
   min_workers                       = var.min_workers

--- a/platform/mwaa/main.tf
+++ b/platform/mwaa/main.tf
@@ -7,7 +7,6 @@ locals {
   default_airflow_configuration_options = {
     "logging.logging_level"      = "INFO"
     "webserver.dag_default_view" = "graph"
-    "webserver.instance_name"    = "${var.prefix} DAGs"
   }
   airflow_configuration_options = merge(local.default_airflow_configuration_options, var.airflow_configuration_options)
 }

--- a/platform/mwaa/main.tf
+++ b/platform/mwaa/main.tf
@@ -7,6 +7,7 @@ locals {
   default_airflow_configuration_options = {
     "logging.logging_level"      = "INFO"
     "webserver.dag_default_view" = "graph"
+    "webserver.instance_name"    = "${var.prefix} DAGs"
   }
   airflow_configuration_options = merge(local.default_airflow_configuration_options, var.airflow_configuration_options)
 }


### PR DESCRIPTION
Summary: Summary of changes

Addresses https://github.com/NASA-IMPACT/veda-data-airflow/issues/161

### Changes
- Adds prefix to the instance name so the UI would have a header of the deployment prefix + "DAGs"
- Passes `airflow_configuration_options` to platform module so that people using this terraform module can add their own airflow configuration options. 