### PR TITLE
feat: add flag to control creation of aws_s3_bucket_public_access_block and add --delete flag to sync

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -80,8 +80,9 @@ module "mwaa" {
   iam_role_permissions_boundary     = var.permissions_boundary_arn
   local_dag_folder                  = var.local_dag_folder == null ? "${path.module}/application/dags/" : var.local_dag_folder
   local_requirement_file_path       = var.local_requirement_file_path == null ? "${path.module}/application/requirements/requirements.txt" : var.local_requirement_file_path
-  local_startup_script_file_path          = var.local_startup_script_file_path
-  tags = local.common_tags
+  local_startup_script_file_path    = var.local_startup_script_file_path
+  tags                              = local.common_tags
+  mcp_deployment                    = var.mcp_deployment
 }
 
 locals {

--- a/main.tf
+++ b/main.tf
@@ -82,7 +82,7 @@ module "mwaa" {
   local_requirement_file_path       = var.local_requirement_file_path == null ? "${path.module}/application/requirements/requirements.txt" : var.local_requirement_file_path
   local_startup_script_file_path    = var.local_startup_script_file_path
   tags                              = local.common_tags
-  mcp_deployment                    = var.mcp_deployment
+  provision_s3_access_block         = var.provision_s3_access_block
 }
 
 locals {

--- a/platform/mwaa/main.tf
+++ b/platform/mwaa/main.tf
@@ -22,7 +22,7 @@ module "s3_bucket" {
   local_startup_script_file_path    = var.local_startup_script_file_path
   local_dag_folder                  = var.local_dag_folder
   tags                              = var.tags
-  mcp_deployment                    = var.mcp_deployment
+  provision_s3_access_block         = var.provision_s3_access_block
 }
 
 

--- a/platform/mwaa/main.tf
+++ b/platform/mwaa/main.tf
@@ -21,7 +21,8 @@ module "s3_bucket" {
   local_requirement_file_path       = var.local_requirement_file_path
   local_startup_script_file_path    = var.local_startup_script_file_path
   local_dag_folder                  = var.local_dag_folder
-  tags = var.tags
+  tags                              = var.tags
+  mcp_deployment                    = var.mcp_deployment
 }
 
 

--- a/platform/mwaa/variables.tf
+++ b/platform/mwaa/variables.tf
@@ -87,8 +87,7 @@ variable "tags" {
   type        = map(string)
 }
 
-variable "mcp_deployment" {
-  description = "Boolean indicating if the deployment is in MCP"
+variable "provision_s3_access_block" {
+  description = "Boolean indicating if aws_s3_bucket_public_access_block resource should be provisionedP"
   type        = bool
-  default     = false
 }

--- a/platform/mwaa/variables.tf
+++ b/platform/mwaa/variables.tf
@@ -86,3 +86,9 @@ variable "tags" {
   description = "A mapping of tags to assign to the resources."
   type        = map(string)
 }
+
+variable "mcp_deployment" {
+  description = "Boolean indicating if the deployment is in MCP"
+  type        = bool
+  default     = false
+}

--- a/platform/s3_bucket/main.tf
+++ b/platform/s3_bucket/main.tf
@@ -35,7 +35,7 @@ resource "aws_s3_bucket_server_side_encryption_configuration" "this" {
 }
 
 resource "aws_s3_bucket_public_access_block" "this" {
-  count = var.provision_s3_access_block == true ? 0 : 1
+  count = var.provision_s3_access_block == true ? 1 : 0
 
   bucket                  = aws_s3_bucket.this.id
   block_public_acls       = true

--- a/platform/s3_bucket/main.tf
+++ b/platform/s3_bucket/main.tf
@@ -64,7 +64,7 @@ resource "null_resource" "upload_dag_folder" {
     src_hash = data.archive_file.monitor_change_in_dag_folder.output_sha
   }
   provisioner "local-exec" {
-    command = "aws s3 sync --exclude 'requirements.txt' --exclude 'startup.sh' --exclude '*' --include '*.py' --include '*.txt' ${var.local_dag_folder} s3://${aws_s3_bucket.this.id}/${var.dag_s3_path}"
+    command = "aws s3 sync --delete --exclude 'requirements.txt' --exclude 'startup.sh' --exclude '*' --include '*.py' --include '*.txt' ${var.local_dag_folder} s3://${aws_s3_bucket.this.id}/${var.dag_s3_path}"
   }
 }
 

--- a/platform/s3_bucket/main.tf
+++ b/platform/s3_bucket/main.tf
@@ -35,8 +35,7 @@ resource "aws_s3_bucket_server_side_encryption_configuration" "this" {
 }
 
 resource "aws_s3_bucket_public_access_block" "this" {
-  # If MCP deployment is true, then do not create resource
-  count = var.mcp_deployment == true ? 0 : 1
+  count = var.provision_s3_access_block == true ? 0 : 1
 
   bucket                  = aws_s3_bucket.this.id
   block_public_acls       = true

--- a/platform/s3_bucket/main.tf
+++ b/platform/s3_bucket/main.tf
@@ -35,6 +35,9 @@ resource "aws_s3_bucket_server_side_encryption_configuration" "this" {
 }
 
 resource "aws_s3_bucket_public_access_block" "this" {
+  # If MCP deployment is true, then do not create resource
+  count = var.mcp_deployment == true ? 0 : 1
+
   bucket                  = aws_s3_bucket.this.id
   block_public_acls       = true
   block_public_policy     = true

--- a/platform/s3_bucket/variables.tf
+++ b/platform/s3_bucket/variables.tf
@@ -38,3 +38,9 @@ variable "tags" {
   description = "A mapping of tags to assign to the resources."
   type        = map(string)
 }
+
+variable "mcp_deployment" {
+  description = "Boolean indicating if the deployment is in MCP"
+  type        = bool
+  default     = false
+}

--- a/platform/s3_bucket/variables.tf
+++ b/platform/s3_bucket/variables.tf
@@ -39,8 +39,7 @@ variable "tags" {
   type        = map(string)
 }
 
-variable "mcp_deployment" {
-  description = "Boolean indicating if the deployment is in MCP"
+variable "provision_s3_access_block" {
+  description = "Boolean indicating if aws_s3_bucket_public_access_block resource should be provisioned"
   type        = bool
-  default     = false
 }

--- a/variables.tf
+++ b/variables.tf
@@ -111,8 +111,7 @@ variable "ecs_containers" {
   default = []
 }
 
-variable "mcp_deployment" {
-  description = "Boolean indicating if the deployment is in MCP"
+variable "provision_s3_access_block" {
+  description = "Boolean indicating if aws_s3_bucket_public_access_block resource should be provisioned"
   type        = bool
-  default     = false
 }

--- a/variables.tf
+++ b/variables.tf
@@ -114,4 +114,5 @@ variable "ecs_containers" {
 variable "provision_s3_access_block" {
   description = "Boolean indicating if aws_s3_bucket_public_access_block resource should be provisioned"
   type        = bool
+  default     = false
 }

--- a/variables.tf
+++ b/variables.tf
@@ -111,4 +111,8 @@ variable "ecs_containers" {
   default = []
 }
 
-
+variable "mcp_deployment" {
+  description = "Boolean indicating if the deployment is in MCP"
+  type        = bool
+  default     = false
+}

--- a/variables.tf
+++ b/variables.tf
@@ -114,5 +114,5 @@ variable "ecs_containers" {
 variable "provision_s3_access_block" {
   description = "Boolean indicating if aws_s3_bucket_public_access_block resource should be provisioned"
   type        = bool
-  default     = false
+  default     = true
 }


### PR DESCRIPTION
### Changes

While trying to test the most recent deployment of this module, we discovered that we lack permission to create the resource `aws_s3_bucket_public_access_block` in an MCP environment. 

- Added flag to indicate if the deployment is in MCP `provision_s3_access_block` which defaults to true (so it is not a breaking change)
- If `provision_s3_access_block` is true, then create `aws_s3_bucket_public_access_block` resource, otherwise don't